### PR TITLE
Add QUERY method

### DIFF
--- a/rfc-http-validate.py
+++ b/rfc-http-validate.py
@@ -34,6 +34,7 @@ REGISTERED_METHODS = [
     "PRI",
     "PROPFIND",
     "PUT",
+    "QUERY",
     "REBIND",
     "REPORT",
     "SEARCH",


### PR DESCRIPTION
...since this tool is complaining about the method being unrecognized in the draft defining that method.  It's not yet registered, but since I don't see a way for the doc to self-describe additional values it adds, this seems the simplest path forward.